### PR TITLE
Fix rootmap/library naming and test dictionaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,5 +56,8 @@ cet_cmake_module_directories(Modules BINARY)
 # source
 add_subdirectory(lareventdisplay)
 
+# tests
+add_subdirectory(test)
+
 # packaging utility
 cet_cmake_config()

--- a/lareventdisplay/EventDisplay/AnalysisBaseDrawer.h
+++ b/lareventdisplay/EventDisplay/AnalysisBaseDrawer.h
@@ -3,9 +3,7 @@
 #ifndef EVD_ANALYSISBASEDRAWER_H
 #define EVD_ANALYSISBASEDRAWER_H
 
-namespace art {
-  class Event;
-}
+#include "art/Framework/Principal/fwd.h"
 
 namespace evdb {
   class View2D;

--- a/lareventdisplay/EventDisplay/CMakeLists.txt
+++ b/lareventdisplay/EventDisplay/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(BuildDictionary)
 
-set(PACKAGE EventDisplay)
+set(PACKAGE lareventdisplay_EventDisplay)
 
 cet_make_library(LIBRARY_NAME SpacePoint3DDrawer INTERFACE
   SOURCE 3DDrawers/ISpacePoints3D.h
@@ -161,7 +161,7 @@ cet_make_library(SOURCE
 include(CetRootCint)
 set(_cet_warn_deprecated ${CET_WARN_DEPRECATED})
 unset(CET_WARN_DEPRECATED)
-cet_rootcint(${PACKAGE} LIB_TARGET lareventdisplay_EventDisplay)
+cet_rootcint(${PACKAGE})
 set(CET_WARN_DEPRECATED ${_cet_warn_deprecated})
 ########################################################################
 

--- a/lareventdisplay/EventDisplay/DrawingPad.h
+++ b/lareventdisplay/EventDisplay/DrawingPad.h
@@ -16,7 +16,6 @@ namespace evd_tool {
 
 namespace evd {
   class HeaderDrawer;
-  //class GeometryDrawer;
   class SimulationDrawer;
   class RawDataDrawer;
   class RecoBaseDrawer;

--- a/lareventdisplay/EventDisplay/HitSelector.h
+++ b/lareventdisplay/EventDisplay/HitSelector.h
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "art/Framework/Principal/fwd.h"
 #include "canvas/Persistency/Common/Ptr.h"
 
 #include "lardataobj/RecoBase/Seed.h"

--- a/lareventdisplay/EventDisplay/RawDataDrawer.h
+++ b/lareventdisplay/EventDisplay/RawDataDrawer.h
@@ -4,21 +4,15 @@
 #ifndef EVD_RAWDATADRAWER_H
 #define EVD_RAWDATADRAWER_H
 
-namespace fhicl {
-  class ParameterSet;
-}
-
+#include "art/Framework/Principal/fwd.h"
+#include "fhiclcpp/fwd.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h" // geo::PlaneID
-
-#include <vector>
 
 #ifndef __CINT__
 #include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h" // lariov::ChannelStatusProvider::Status_t
 #endif
 
-namespace art {
-  class Event;
-}
+#include <vector>
 
 class TH1F;
 class TVirtualPad;

--- a/lareventdisplay/EventDisplay/SimulationDrawer.h
+++ b/lareventdisplay/EventDisplay/SimulationDrawer.h
@@ -10,9 +10,7 @@
 #include <string>
 #include <vector>
 
-namespace art {
-  class Event;
-}
+#include "art/Framework/Principal/fwd.h"
 #include "lareventdisplay/EventDisplay/OrthoProj.h"
 
 namespace evdb {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,19 @@
+include(CetTest)
+cet_enable_asserts()
+
+# Tests to ensure well-formed dictionaries for the event-display
+# classes (should be able to create a null pointer in ROOT).
+
+function(evd_dictionary_test CLASS)
+  cet_test(${CLASS}_t HANDBUILT
+    TEST_EXEC root.exe
+    TEST_ARGS -l -q -b -e "evd::${CLASS} const* x = nullptr;")
+endfunction()
+
+evd_dictionary_test(TWQProjectionView)
+evd_dictionary_test(TWQMultiTPCProjectionView)
+evd_dictionary_test(Display3DView)
+evd_dictionary_test(Ortho3DView)
+evd_dictionary_test(Ortho3DPad)
+evd_dictionary_test(CalorView)
+evd_dictionary_test(DrawingPad)


### PR DESCRIPTION
This PR fixes an inconsistency between the library name recorded in the rootmap file and the name of the .so file.

It also adds unit tests to make sure that ROOT can correctly parse the class names of the types in the dictionary.