### PR TITLE
Remove use of art's `art::Event::getView`

### DIFF
--- a/lareventdisplay/EventDisplay/RecoBaseDrawer.h
+++ b/lareventdisplay/EventDisplay/RecoBaseDrawer.h
@@ -288,13 +288,10 @@ namespace evd {
                  const art::InputTag& which,
                  std::vector<art::Ptr<recob::Edge>>& edges);
 
-    int GetTracks(const art::Event& evt,
-                  const art::InputTag& which,
-                  art::View<recob::Track>& track);
-
-    int GetShowers(const art::Event& evt,
-                   const art::InputTag& which,
-                   art::View<recob::Shower>& shower);
+    art::Handle<std::vector<recob::Track>> GetTracks(const art::Event& evt,
+                                                     const art::InputTag& which);
+    art::Handle<std::vector<recob::Shower>> GetShowers(const art::Event& evt,
+                                                       const art::InputTag& which);
 
     int GetVertices(const art::Event& evt,
                     const art::InputTag& which,

--- a/lareventdisplay/EventDisplay/SimulationDrawer.cxx
+++ b/lareventdisplay/EventDisplay/SimulationDrawer.cxx
@@ -891,20 +891,22 @@ namespace evd {
 
     art::ServiceHandle<evd::SimulationDrawingOptions const> drawopt;
 
-    std::vector<const simb::MCParticle*> temp;
-
-    art::View<simb::MCParticle> plcol;
-    // use get by Type because there should only be one collection of these in the event
+    auto mcpsH = evt.getHandle<std::vector<simb::MCParticle>>(drawopt->fG4ModuleLabel);
     try {
-      evt.getView(drawopt->fG4ModuleLabel, plcol);
-      for (unsigned int i = 0; i < plcol.vals().size(); ++i) {
-        temp.push_back(plcol.vals().at(i));
-      }
-      temp.swap(plist);
+      *mcpsH;
     }
     catch (cet::exception& e) {
       writeErrMsg("GetRawDigits", e);
+      return 0;
     }
+
+    std::vector<const simb::MCParticle*> result;
+    result.reserve(mcpsH->size());
+    for (simb::MCParticle const& mcp : *mcpsH) {
+      result.push_back(&mcp);
+    }
+
+    std::swap(result, plist);
 
     return plist.size();
   }


### PR DESCRIPTION
All instances of `art::Event::getView(...)` are unnecessary as only data products of the type `std::vector<T>`s are retrieved when `getView(...)` is called.  Because the Phlex framework will not support the equivalent of art views, this PR removes their unnecessary use.